### PR TITLE
Improve serial settings configuration and validation

### DIFF
--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1164,7 +1164,7 @@ const SettingsField::FieldInfo SettingsField::fields[SettingsField::NumberOfFiel
     {WifiPassword, "wifi password", nullptr, 65},
     {MqttBrokerAddress, "mqtt broker network address", nullptr, 21},
     {MqttBrokerPort, "mqtt broker network port", "1883", 7},
-    {MqttCertificateFingerprint, "mqtt broker certificate fingerprint ('[insecure]' disables TLS)", "[insecure]", 45},
+    {MqttCertificateFingerprint, "mqtt broker certificate sha1 fingerprint ('[insecure]' disables TLS)", "[insecure]", 45},
     {MqttBrokerUser, "mqtt broker user name", "power-meter", 21},
     {MqttBrokerPassword, "mqtt broker password", nullptr, 21},
     {MqttBrokerClientId, "mqtt broker client id", nullptr, 21},

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -2559,8 +2559,19 @@ u32 readSerialLine(Buffer& buffer) {
             continue;
         }
 
+        // Return key
         if (c == 0x0d) {
             break;
+        }
+
+        // Backspace key
+        if (c == 0x08 ) {
+            if (index > 0) {
+                buffer[--index] = '\0';
+                Serial.print("\r\n");
+                Serial.print(buffer.charBegin());
+            }
+            continue;
         }
 
         Serial.write(c);

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1059,7 +1059,7 @@ public:
 
     ErrorOr<void> validate(Buffer& buffer) const {
         auto validateAndCompactHexString = [&buffer](i32 numDigits) -> ErrorOr<void> {
-            for (u32 i = 0; i != buffer.length(); i++) {
+            for (u32 i = 0; i != buffer.length()-1; i++) {
                 auto c = buffer[i];
                 if (!(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F') && !(c >= '0' && c <= '9')) {
                     return Error{ "Bad hex character. Expected range is [a-fA-F0-9]" };
@@ -1070,7 +1070,7 @@ public:
         };
 
         auto validateLength = [&buffer](u32 len) -> ErrorOr<void> {
-            if (buffer.length() != len) {
+            if (buffer.length()-1 != len) {
                 return Error{ "" };
             }
             return {};
@@ -1078,7 +1078,7 @@ public:
 
         switch (type) {
         case MqttBrokerPort:
-            for (u32 i = 0; i != buffer.length(); i++) {
+            for (u32 i = 0; i != buffer.length()-1; i++) {
                 if (buffer[i] < '0' || buffer[i] > '9') {
                     return Error{ "Bad digit. Expected positive integer" };
                 }
@@ -1104,7 +1104,7 @@ public:
             }
             break;
         default:
-            if (buffer.length() > maxLength() - 1) {
+            if (buffer.length() > maxLength()) {
                 return Error{ "Input is too long. Not enough space. " };
             }
             break;
@@ -2703,7 +2703,11 @@ void runSetupWizard(bool oldDataIsValid) {
                 length = strnlen(buffer.charBegin(), 150);
             }
 
-            buffer.shrinkLength(length);
+            if (length >= 150) {
+                length = 149;
+            }
+            buffer[length] = '\0';
+            buffer.shrinkLength(length+1);
 
             // Validation
             auto validationError = field.validate(buffer);

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1084,6 +1084,16 @@ public:
             return {};
         };
 
+        auto validatePrintableASCII = [&buffer]() -> ErrorOr<void> {
+            for (u32 i = 0; i != buffer.length() - 1; i++) {
+                if (buffer[i] < 32 || buffer[i] > 126) {
+                    return Error{ "Bad unprintable ASCII character found" };
+                }
+            }
+
+            return {};
+        };
+
         auto validateLength = [&buffer](u32 len) -> ErrorOr<void> {
             if (buffer.length()-1 != len) {
                 return Error{ "" };
@@ -1120,6 +1130,7 @@ public:
             if (buffer.length() > maxLength()) {
                 return Error{ "Input is too long. Not enough space. " };
             }
+            TRY(validatePrintableASCII());
             break;
         }
 

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1212,13 +1212,13 @@ public:
                 getCString(field, buffer);
                 stream << "* " << field.name() << ": " << buffer.charBegin() << "\r\n";
             }
-        });
+            });
     }
 
     void erase() {
         auto storageSize = SettingsField::requiredStorage();
         for (u32 i = 0; i != storageSize; i++) {
-            eeprom[i]= 0;
+            eeprom[i] = 0;
         }
         eeprom[storageSize] = 0xff; // Set bad checksum
         eeprom.commit();
@@ -2611,7 +2611,7 @@ void initMqtt() {
         else {
             debugOut << "Creating secure wifi client with fingerprint: " << fingerprint.charBegin() << debugEndl;
 
-            auto client= NoStl::makeUnique<WiFiClientSecure>();
+            auto client = NoStl::makeUnique<WiFiClientSecure>();
             client->setFingerprint(fingerprint.charBegin());
             wifiClient = NoStl::move(client);
         }
@@ -2645,16 +2645,16 @@ void initMqtt() {
         switch (mqttMessageMode.at(0)) {
         case '0':
             debugOut << "Creating mqtt RAW sender" << debugEndl;
-            mqttSender = NoStl::makeUnique<MqttRawSender<decltype(pubsubClient)>>( pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin() );
+            mqttSender = NoStl::makeUnique<MqttRawSender<decltype(pubsubClient)>>(pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin());
             break;
         case '1':
             debugOut << "Creating mqtt TOPIC sender" << debugEndl;
-            mqttSender = NoStl::makeUnique<MqttTopicSender<decltype(pubsubClient)>>( pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin() );
+            mqttSender = NoStl::makeUnique<MqttTopicSender<decltype(pubsubClient)>>(pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin());
             break;
         case '2':
         default:
             debugOut << "Creating mqtt JSON sender" << debugEndl;
-            mqttSender = NoStl::makeUnique<MqttJsonSender<decltype(pubsubClient)>>( pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin() );
+            mqttSender = NoStl::makeUnique<MqttJsonSender<decltype(pubsubClient)>>(pubsubClient, basePath.charBegin(), mqttClient.charBegin(), mqttUser.charBegin(), mqttPassword.charBegin());
             break;
         }
     }
@@ -2677,7 +2677,8 @@ void runSetupWizard(bool oldDataIsValid) {
                 auto shownValue = field.isSecure() ? "<hidden-value>" : defaultValue;
                 serialStream << " or just press enter to confirm old value (" << shownValue << ") ";
 
-            } else if (field.defaultValue()) {
+            }
+            else if (field.defaultValue()) {
                 defaultValue = field.defaultValue();
                 serialStream << " or just press enter to confirm default value (" << defaultValue << ") ";
             }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ WiFi SSID || SSID of the WiFi station to connect to |
 WiFI password || Password of the WiFi station to connect to |
 MQTT broker network address || Domain/IP of the MQTT broker server |
 MQTT broker network port | 1883 | Network port of the MQTT broker server |
-MQTT broker certificate fingerprint | [insecure] | Fingerprint of the SSL certificate of the MQTT broker server as hex string. If set to `[insecure]` TLS is disabled and all data is sent as plaint text |
+MQTT broker certificate fingerprint | [insecure] | SHA1 fingerprint of the SSL certificate of the MQTT broker server as hex string. If set to `[insecure]` TLS is disabled and all data is sent as plaint text |
 MQTT broker user name | power-meter | User name to authenticate at the MQTT broker server |
 MQTT broker password || Password to authenticate at the MQTT broker server |
 MQTT broker client id || Client id to register as at the MQTT broker server |


### PR DESCRIPTION
- Validate all text fields to only contain printable characters
- Add support for the backspace key
- Add support for space characters in hex strings (dlms/cosem key, certificate fingerprint)
- Rename "certificate fingerprint" field to "certificate sha1 fingerprint" to make clear which kind of hash is required