### PR TITLE
Disable forced debug printing

### DIFF
--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1073,7 +1073,8 @@ public:
                 }
             }
 
-            buffer.shrinkLength(compactingOffset);
+            buffer[compactingOffset] = '\0';
+            buffer.shrinkLength(compactingOffset+1);
 
             if (numDigits > 0) {
                 return Error{ "Too few hex digits" };

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -99,7 +99,7 @@
 #ifdef _DEBUG
 #define DEBUG_PRINTING 1
 #else
-#define DEBUG_PRINTING 1
+#define DEBUG_PRINTING 0
 #endif
 
 using u8 = uint8_t;

--- a/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
+++ b/Kaifa_to_MQTT_ESP8266/Kaifa_to_MQTT_ESP8266.ino
@@ -1050,6 +1050,7 @@ public:
         switch (type) {
         case WifiPassword:
         case MqttBrokerPassword:
+        case MqttCertificateFingerprint:
         case DslmCosemDecryptionKey:
             return true;
         default:


### PR DESCRIPTION
- Disable forced debug printing
- Mark certificate fingerprint settings field as secure
- Null terminate buffers after hex string compaction